### PR TITLE
fix(content): restore Gensler-faithful answers in Sets A, L, and N

### DIFF
--- a/content/sets/__snapshots__/setA.generator.test.ts.snap
+++ b/content/sets/__snapshots__/setA.generator.test.ts.snap
@@ -22,26 +22,27 @@ exports[`setA generator — top-level > matches snapshot for seed 42 1`] = `
           "correctId": [
             0,
           ],
-          "id": "gen.A.12.0",
+          "id": "gen.A.11.0",
           "options": [
             {
               "id": 0,
-              "label": "all N is D",
+              "label": "no D is N",
             },
             {
               "id": 1,
-              "label": "some N is D",
+              "label": "all D is not N",
             },
             {
               "id": 2,
-              "label": "all n is d",
+              "label": "D is not N",
             },
             {
+              "hint": "The term “clean druggist” could describe many persons, and so translates into a capital letter.",
               "id": 3,
-              "label": "N is D",
+              "label": "d is not N",
             },
           ],
-          "prompt": "All notorious people are druggists.",
+          "prompt": "No clean druggist is notorious.",
         },
         {
           "answer": "",
@@ -78,7 +79,90 @@ exports[`setA generator — top-level > matches snapshot for seed 42 1`] = `
           "correctId": [
             0,
           ],
-          "id": "gen.A.11.2",
+          "id": "gen.A.10.2",
+          "options": [
+            {
+              "id": 0,
+              "label": "some D is C",
+            },
+            {
+              "id": 1,
+              "label": "D is C",
+            },
+            {
+              "hint": "“careful” could describe many persons, and so translates into a capital letter.",
+              "id": 2,
+              "label": "D is c",
+            },
+            {
+              "hint": "“careful” could describe many persons, and so translates into a capital letter.",
+              "id": 3,
+              "label": "some D is c",
+            },
+          ],
+          "prompt": "Some poetic dentists are careful.",
+        },
+        {
+          "answer": "",
+          "correctId": [
+            0,
+          ],
+          "id": "gen.A.11.3",
+          "options": [
+            {
+              "id": 0,
+              "label": "no P is R",
+            },
+            {
+              "id": 1,
+              "label": "all P is not R",
+            },
+            {
+              "id": 2,
+              "label": "P is not R",
+            },
+            {
+              "hint": "The term “talented professor” could describe many persons, and so translates into a capital letter.",
+              "id": 3,
+              "label": "p is not R",
+            },
+          ],
+          "prompt": "No talented professor is remarkable.",
+        },
+        {
+          "answer": "",
+          "correctId": [
+            0,
+          ],
+          "id": "gen.A.4.4",
+          "options": [
+            {
+              "id": 0,
+              "label": "p is not F",
+            },
+            {
+              "hint": "“A fortunate person” could describe many persons, and so translates into a capital letter.",
+              "id": 1,
+              "label": "p is not f",
+            },
+            {
+              "id": 2,
+              "label": "P is not F",
+            },
+            {
+              "hint": "“A fortunate person” could describe many persons, and so translates into a capital letter.",
+              "id": 3,
+              "label": "P is not f",
+            },
+          ],
+          "prompt": "This pessimist isn't a fortunate person.",
+        },
+        {
+          "answer": "",
+          "correctId": [
+            0,
+          ],
+          "id": "gen.A.11.5",
           "options": [
             {
               "id": 0,
@@ -93,205 +177,122 @@ exports[`setA generator — top-level > matches snapshot for seed 42 1`] = `
               "label": "D is not C",
             },
             {
-              "hint": "The term “poetic dentist” could describe many persons, and so translates into a capital letter.",
+              "hint": "The term “romantic diabetic” could describe many persons, and so translates into a capital letter.",
               "id": 3,
               "label": "d is not C",
             },
           ],
-          "prompt": "No poetic dentist is careful.",
+          "prompt": "No romantic diabetic is clean.",
         },
         {
           "answer": "",
           "correctId": [
             0,
           ],
-          "id": "gen.A.12.3",
+          "id": "gen.A.4.6",
           "options": [
             {
               "id": 0,
-              "label": "all R is P",
-            },
-            {
-              "id": 1,
-              "label": "some R is P",
-            },
-            {
-              "id": 2,
-              "label": "all r is p",
-            },
-            {
-              "id": 3,
-              "label": "R is P",
-            },
-          ],
-          "prompt": "All remarkable people are professors.",
-        },
-        {
-          "answer": "",
-          "correctId": [
-            0,
-          ],
-          "id": "gen.A.5.4",
-          "options": [
-            {
-              "id": 0,
-              "label": "p is not f",
-            },
-            {
-              "hint": "“The most fortunate person” stands for a single person, and so translates into a small letter.",
-              "id": 1,
-              "label": "p is not F",
-            },
-            {
-              "id": 2,
-              "label": "P is not f",
-            },
-            {
-              "hint": "“The most fortunate person” stands for a single person, and so translates into a small letter.",
-              "id": 3,
-              "label": "P is not F",
-            },
-          ],
-          "prompt": "This pessimist isn't the most fortunate person.",
-        },
-        {
-          "answer": "",
-          "correctId": [
-            0,
-          ],
-          "id": "gen.A.12.5",
-          "options": [
-            {
-              "id": 0,
-              "label": "some C is D",
-            },
-            {
-              "id": 1,
-              "label": "all C is D",
-            },
-            {
-              "id": 2,
-              "label": "some c is d",
-            },
-            {
-              "id": 3,
-              "label": "C is D",
-            },
-          ],
-          "prompt": "Some clean people are diabetics.",
-        },
-        {
-          "answer": "",
-          "correctId": [
-            0,
-          ],
-          "id": "gen.A.5.6",
-          "options": [
-            {
-              "id": 0,
-              "label": "p is not b",
-            },
-            {
-              "hint": "“The most boastful person” stands for a single person, and so translates into a small letter.",
-              "id": 1,
               "label": "p is not B",
             },
             {
-              "id": 2,
-              "label": "P is not b",
+              "hint": "“A boastful person” could describe many persons, and so translates into a capital letter.",
+              "id": 1,
+              "label": "p is not b",
             },
             {
-              "hint": "“The most boastful person” stands for a single person, and so translates into a small letter.",
-              "id": 3,
+              "id": 2,
               "label": "P is not B",
             },
+            {
+              "hint": "“A boastful person” could describe many persons, and so translates into a capital letter.",
+              "id": 3,
+              "label": "P is not b",
+            },
           ],
-          "prompt": "This prisoner isn't the most boastful person.",
+          "prompt": "This prisoner isn't a boastful person.",
         },
         {
           "answer": "",
           "correctId": [
             0,
           ],
-          "id": "gen.A.10.7",
+          "id": "gen.A.9.7",
           "options": [
             {
               "id": 0,
-              "label": "some N is G",
+              "label": "some N is not H",
             },
             {
+              "hint": "You forgot the ‘not.’",
               "id": 1,
-              "label": "N is G",
+              "label": "some N is H",
             },
             {
               "id": 2,
-              "label": "some n is g",
+              "label": "N is not H",
             },
             {
-              "hint": "Why did you switch the letters around?",
               "id": 3,
-              "label": "some G is N",
+              "label": "some n is not H",
             },
           ],
-          "prompt": "Some virtuous novelists are greedy.",
+          "prompt": "Some novelists don't help any virtuous people.",
         },
         {
           "answer": "",
           "correctId": [
             0,
           ],
-          "id": "gen.A.4.8",
+          "id": "gen.A.3.8",
           "options": [
             {
               "id": 0,
-              "label": "j is not S",
+              "label": "i is j",
             },
             {
-              "hint": "“A sociable person” could describe many persons, and so translates into a capital letter.",
+              "hint": "“The most sociable judge” stands for a single person, and so translates into a small letter.",
               "id": 1,
-              "label": "j is not s",
+              "label": "i is J",
             },
             {
               "id": 2,
-              "label": "J is not S",
+              "label": "I is j",
             },
             {
-              "hint": "“A sociable person” could describe many persons, and so translates into a capital letter.",
+              "hint": "“The most sociable judge” stands for a single person, and so translates into a small letter.",
               "id": 3,
-              "label": "J is not s",
+              "label": "I is J",
             },
           ],
-          "prompt": "This judge isn't a sociable person.",
+          "prompt": "I'm the most sociable judge in Berlin.",
         },
         {
           "answer": "",
           "correctId": [
             0,
           ],
-          "id": "gen.A.0.9",
+          "id": "gen.A.9.9",
           "options": [
             {
               "id": 0,
-              "label": "k is L",
+              "label": "some S is not I",
             },
             {
-              "hint": "“A logical person in Hamburg” could describe many persons, and so translates into a capital letter.",
+              "hint": "You forgot the ‘not.’",
               "id": 1,
-              "label": "k is l",
+              "label": "some S is I",
             },
             {
-              "hint": "“Keith” stands for a single person, and so translates into a small letter.",
               "id": 2,
-              "label": "K is L",
+              "label": "S is not I",
             },
             {
-              "hint": "“Keith” stands for a single person, and so translates into a small letter.
-“A logical person in Hamburg” could describe many persons, and so translates into a capital letter.",
               "id": 3,
-              "label": "K is l",
+              "label": "some s is not I",
             },
           ],
-          "prompt": "Keith is a logical person in Hamburg.",
+          "prompt": "Some senators don't injure any persistent people.",
         },
       ],
       "shuffleOptions": true,
@@ -456,30 +457,28 @@ exports[`setA generator — top-level > matches snapshot for seed 42 1`] = `
           "correctId": [
             0,
           ],
-          "id": "gen.A.1.5",
+          "id": "gen.A.12.5",
           "options": [
             {
               "id": 0,
-              "label": "g is h",
+              "label": "all P is G",
             },
             {
-              "hint": "“The most hideous one in Hamburg” stands for a single person, and so translates into a small letter.",
+              "hint": "You have to switch the parts around with ‘none but.’ ‘None but men are NFL football players’ doesn’t mean ‘all men are NFL football players’ — it means ‘all NFL football players are men.’",
               "id": 1,
-              "label": "g is H",
+              "label": "all G is P",
             },
             {
-              "hint": "“George” stands for a single person, and so translates into a small letter.",
+              "hint": "‘Only’ isn’t part of the wff language — translate it as an ‘all’-sentence with the parts switched around.",
               "id": 2,
-              "label": "G is h",
+              "label": "only G is P",
             },
             {
-              "hint": "“George” stands for a single person, and so translates into a small letter.
-“The most hideous one in Hamburg” stands for a single person, and so translates into a small letter.",
               "id": 3,
-              "label": "G is H",
+              "label": "G is P",
             },
           ],
-          "prompt": "George is the most hideous one in Hamburg.",
+          "prompt": "None but greedy people are plumbers.",
         },
         {
           "answer": "",

--- a/content/sets/__snapshots__/setL.generator.test.ts.snap
+++ b/content/sets/__snapshots__/setL.generator.test.ts.snap
@@ -155,28 +155,28 @@ The antecedent is descriptive — don’t underline u in Dgu.",
           "options": [
             {
               "id": 0,
+              "label": "$ (R\\underline{u} \\supset  Su) $",
+            },
+            {
+              "hint": "Conditional with imperative consequent: only the consequent letter is underlined — \`(Su ⊃ L{u})\` reads ‘if you’re sleeping, then leave’.
+‘Do A, only if B’ makes the imperative the antecedent: (A̲ ⊃ B) — the same as ‘If you aren’t selling, then don’t repent’: (∼B ⊃ ∼A̲).",
+              "id": 1,
               "label": "$ (Su \\supset  R\\underline{u}) $",
             },
             {
               "hint": "Conditional with imperative consequent: only the consequent letter is underlined — \`(Su ⊃ L{u})\` reads ‘if you’re sleeping, then leave’.
-The antecedent is descriptive (‘you’re selling’), not imperative — don’t underline the u in Su.",
-              "id": 1,
-              "label": "$ (S\\underline{u} \\supset  R\\underline{u}) $",
-            },
-            {
-              "hint": "Conditional with imperative consequent: only the consequent letter is underlined — \`(Su ⊃ L{u})\` reads ‘if you’re sleeping, then leave’.
-You forgot to underline the imperative agent letter — descriptive \`Au\` and imperative \`A{u}\` are different wffs. (The consequent is the imperative.)",
+You forgot to underline the imperative agent letter — descriptive \`Au\` and imperative \`A{u}\` are different wffs. (The antecedent is the imperative.)",
               "id": 2,
-              "label": "$ (Su \\supset  Ru) $",
+              "label": "$ (Ru \\supset  Su) $",
             },
             {
               "hint": "Conditional with imperative consequent: only the consequent letter is underlined — \`(Su ⊃ L{u})\` reads ‘if you’re sleeping, then leave’.
-‘If A then B’ is \`(A ⊃ B)\`, not \`(A · B)\`.",
+‘A only if B’ is a conditional \`(A ⊃ B)\`, not \`(A · B)\`.",
               "id": 3,
-              "label": "$ (Su \\cdot  R\\underline{u}) $",
+              "label": "$ (R\\underline{u} \\cdot  Su) $",
             },
           ],
-          "prompt": "If you’re selling, then repent.",
+          "prompt": "Do repent, only if you sell.",
         },
         {
           "answer": "",

--- a/content/sets/__snapshots__/setN.generator.test.ts.snap
+++ b/content/sets/__snapshots__/setN.generator.test.ts.snap
@@ -363,28 +363,28 @@ You inverted the negations — the prompt says you DON’T believe both.",
           "options": [
             {
               "id": 0,
-              "label": "$ \\sim (\\underline{u}:C\\underline{u} \\cdot  \\sim Cu) $",
+              "label": "$ \\sim (\\underline{u}:OC\\underline{u} \\cdot  \\sim \\underline{u}:C\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-‘Don’t combine A with B’ is the don’t-combine form \`∼(A · B)\`, not the if-then \`(A ⊃ ∼B)\`.",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+‘Acting to conform’ is itself a willing formula — \`{u}:C{u}\`, not bare \`C{u}\`. Underline both parts, including the u before the second colon.",
               "id": 1,
-              "label": "$ (\\underline{u}:C\\underline{u} \\supset  Cu) $",
+              "label": "$ \\sim (\\underline{u}:OC\\underline{u} \\cdot  \\sim C\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-The second conjunct is descriptive (you don’t actually conform) — don’t underline the u in Cu.",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+Use a formula that forbids a combination — the don’t-combine imperative is \`∼( · )\` with the u’s before the colons underlined.",
               "id": 2,
-              "label": "$ \\sim (\\underline{u}:C\\underline{u} \\cdot  \\sim C\\underline{u}) $",
+              "label": "$ (u:OC\\underline{u} \\cdot  \\sim \\underline{u}:C\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-You forgot to underline the u — descriptive \`u:A\` and imperative \`{u}:A\` are different wffs. (The inner C{u} is imperative — what you’re wanting yourself to do.)",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+This describes you (a statement), it doesn’t forbid anything — the imperative is \`∼( · )\` with both parts underlined.",
               "id": 3,
-              "label": "$ \\sim (\\underline{u}:Cu \\cdot  \\sim Cu) $",
+              "label": "$ (u:OC\\underline{u} \\cdot  \\sim C\\underline{u}) $",
             },
           ],
-          "prompt": "Don’t combine wanting yourself to conform with not conforming.",
+          "prompt": "Don’t combine believing that you ought to conform with not acting to conform.",
         },
         {
           "answer": "",
@@ -395,28 +395,28 @@ You forgot to underline the u — descriptive \`u:A\` and imperative \`{u}:A\` a
           "options": [
             {
               "id": 0,
-              "label": "$ \\sim (\\underline{u}:P\\underline{u} \\cdot  \\sim Pu) $",
+              "label": "$ \\sim (\\underline{u}:OP\\underline{u} \\cdot  \\sim \\underline{u}:P\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-‘Don’t combine A with B’ is the don’t-combine form \`∼(A · B)\`, not the if-then \`(A ⊃ ∼B)\`.",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+‘Acting to pray’ is itself a willing formula — \`{u}:P{u}\`, not bare \`P{u}\`. Underline both parts, including the u before the second colon.",
               "id": 1,
-              "label": "$ (\\underline{u}:P\\underline{u} \\supset  Pu) $",
+              "label": "$ \\sim (\\underline{u}:OP\\underline{u} \\cdot  \\sim P\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-The second conjunct is descriptive (you don’t actually pray) — don’t underline the u in Pu.",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+Use a formula that forbids a combination — the don’t-combine imperative is \`∼( · )\` with the u’s before the colons underlined.",
               "id": 2,
-              "label": "$ \\sim (\\underline{u}:P\\underline{u} \\cdot  \\sim P\\underline{u}) $",
+              "label": "$ (u:OP\\underline{u} \\cdot  \\sim \\underline{u}:P\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-You forgot to underline the u — descriptive \`u:A\` and imperative \`{u}:A\` are different wffs. (The inner P{u} is imperative — what you’re wanting yourself to do.)",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+This describes you (a statement), it doesn’t forbid anything — the imperative is \`∼( · )\` with both parts underlined.",
               "id": 3,
-              "label": "$ \\sim (\\underline{u}:Pu \\cdot  \\sim Pu) $",
+              "label": "$ (u:OP\\underline{u} \\cdot  \\sim P\\underline{u}) $",
             },
           ],
-          "prompt": "Don’t want to pray without actually praying.",
+          "prompt": "Don’t combine believing that you ought to pray with not acting to pray.",
         },
         {
           "answer": "",
@@ -491,28 +491,28 @@ Since the sentence DESCRIBES what you believe, the letter before ‘:’ should 
           "options": [
             {
               "id": 0,
-              "label": "$ \\sim (\\underline{u}:F\\underline{u} \\cdot  \\sim Fu) $",
+              "label": "$ \\sim (\\underline{u}:OF\\underline{u} \\cdot  \\sim \\underline{u}:F\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-‘Don’t combine A with B’ is the don’t-combine form \`∼(A · B)\`, not the if-then \`(A ⊃ ∼B)\`.",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+‘Acting to forfeit’ is itself a willing formula — \`{u}:F{u}\`, not bare \`F{u}\`. Underline both parts, including the u before the second colon.",
               "id": 1,
-              "label": "$ (\\underline{u}:F\\underline{u} \\supset  Fu) $",
+              "label": "$ \\sim (\\underline{u}:OF\\underline{u} \\cdot  \\sim F\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-The second conjunct is descriptive (you don’t actually forfeit) — don’t underline the u in Fu.",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+Use a formula that forbids a combination — the don’t-combine imperative is \`∼( · )\` with the u’s before the colons underlined.",
               "id": 2,
-              "label": "$ \\sim (\\underline{u}:F\\underline{u} \\cdot  \\sim F\\underline{u}) $",
+              "label": "$ (u:OF\\underline{u} \\cdot  \\sim \\underline{u}:F\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-You forgot to underline the u — descriptive \`u:A\` and imperative \`{u}:A\` are different wffs. (The inner F{u} is imperative — what you’re wanting yourself to do.)",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+This describes you (a statement), it doesn’t forbid anything — the imperative is \`∼( · )\` with both parts underlined.",
               "id": 3,
-              "label": "$ \\sim (\\underline{u}:Fu \\cdot  \\sim Fu) $",
+              "label": "$ (u:OF\\underline{u} \\cdot  \\sim F\\underline{u}) $",
             },
           ],
-          "prompt": "Don’t combine wanting yourself to forfeit with not forfeiting.",
+          "prompt": "Don’t combine believing that you ought to forfeit with not acting to forfeit.",
         },
         {
           "answer": "",
@@ -587,28 +587,28 @@ You forgot to underline the x — descriptive \`u:A\` and imperative \`{u}:A\` a
           "options": [
             {
               "id": 0,
-              "label": "$ \\sim (\\underline{u}:I\\underline{u} \\cdot  \\sim Iu) $",
+              "label": "$ \\sim (\\underline{u}:OI\\underline{u} \\cdot  \\sim \\underline{u}:I\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-‘Don’t combine A with B’ is the don’t-combine form \`∼(A · B)\`, not the if-then \`(A ⊃ ∼B)\`.",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+‘Acting to invest’ is itself a willing formula — \`{u}:I{u}\`, not bare \`I{u}\`. Underline both parts, including the u before the second colon.",
               "id": 1,
-              "label": "$ (\\underline{u}:I\\underline{u} \\supset  Iu) $",
+              "label": "$ \\sim (\\underline{u}:OI\\underline{u} \\cdot  \\sim I\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-The second conjunct is descriptive (you don’t actually invest) — don’t underline the u in Iu.",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+Use a formula that forbids a combination — the don’t-combine imperative is \`∼( · )\` with the u’s before the colons underlined.",
               "id": 2,
-              "label": "$ \\sim (\\underline{u}:I\\underline{u} \\cdot  \\sim I\\underline{u}) $",
+              "label": "$ (u:OI\\underline{u} \\cdot  \\sim \\underline{u}:I\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-You forgot to underline the u — descriptive \`u:A\` and imperative \`{u}:A\` are different wffs. (The inner I{u} is imperative — what you’re wanting yourself to do.)",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+This describes you (a statement), it doesn’t forbid anything — the imperative is \`∼( · )\` with both parts underlined.",
               "id": 3,
-              "label": "$ \\sim (\\underline{u}:Iu \\cdot  \\sim Iu) $",
+              "label": "$ (u:OI\\underline{u} \\cdot  \\sim I\\underline{u}) $",
             },
           ],
-          "prompt": "Don’t want to invest without actually investing.",
+          "prompt": "Don’t combine believing that you ought to invest with not acting to invest.",
         },
         {
           "answer": "",
@@ -619,28 +619,28 @@ You forgot to underline the u — descriptive \`u:A\` and imperative \`{u}:A\` a
           "options": [
             {
               "id": 0,
-              "label": "$ \\sim (\\underline{u}:G\\underline{u} \\cdot  \\sim Gu) $",
+              "label": "$ \\sim (\\underline{u}:OG\\underline{u} \\cdot  \\sim \\underline{u}:G\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-‘Don’t combine A with B’ is the don’t-combine form \`∼(A · B)\`, not the if-then \`(A ⊃ ∼B)\`.",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+‘Acting to groan’ is itself a willing formula — \`{u}:G{u}\`, not bare \`G{u}\`. Underline both parts, including the u before the second colon.",
               "id": 1,
-              "label": "$ (\\underline{u}:G\\underline{u} \\supset  Gu) $",
+              "label": "$ \\sim (\\underline{u}:OG\\underline{u} \\cdot  \\sim G\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-The second conjunct is descriptive (you don’t actually groan) — don’t underline the u in Gu.",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+Use a formula that forbids a combination — the don’t-combine imperative is \`∼( · )\` with the u’s before the colons underlined.",
               "id": 2,
-              "label": "$ \\sim (\\underline{u}:G\\underline{u} \\cdot  \\sim G\\underline{u}) $",
+              "label": "$ (u:OG\\underline{u} \\cdot  \\sim \\underline{u}:G\\underline{u}) $",
             },
             {
-              "hint": "‘Don’t combine wanting yourself to do A with not doing A’ → \`∼({u}:A{u} · ∼Au)\`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.
-You forgot to underline the u — descriptive \`u:A\` and imperative \`{u}:A\` are different wffs. (The inner G{u} is imperative — what you’re wanting yourself to do.)",
+              "hint": "‘Don’t combine believing that you ought to do A with not acting to do A’ → \`∼({u}:OA{u} · ∼{u}:A{u})\`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.
+This describes you (a statement), it doesn’t forbid anything — the imperative is \`∼( · )\` with both parts underlined.",
               "id": 3,
-              "label": "$ \\sim (\\underline{u}:Gu \\cdot  \\sim Gu) $",
+              "label": "$ (u:OG\\underline{u} \\cdot  \\sim G\\underline{u}) $",
             },
           ],
-          "prompt": "Don’t both want yourself to groan and fail to groan.",
+          "prompt": "Don’t believe that you ought to groan without acting to groan.",
         },
         {
           "answer": "",

--- a/content/sets/setA.generator.test.ts
+++ b/content/sets/setA.generator.test.ts
@@ -190,6 +190,69 @@ describe('setA generator — Gensler fidelity', () => {
       }
     }
   );
+
+  /** Gensler's 2008 grader treats four forms as order-insensitive
+   *  ("the order doesn't matter with these four forms"):
+   *  some A is B = some B is A; no A is B = no B is A;
+   *  x is y = y is x; x is not y = y is not x.
+   *  A distractor that is an order-swap of the correct answer is
+   *  therefore a correct answer marked wrong (the *10 P0 bug). */
+  const orderSwapped = (label: string): string | null => {
+    let m = label.match(/^some ([A-Za-z]) is ([A-Za-z])$/);
+    if (m) return `some ${m[2]} is ${m[1]}`;
+    m = label.match(/^no ([A-Za-z]) is ([A-Za-z])$/);
+    if (m) return `no ${m[2]} is ${m[1]}`;
+    m = label.match(/^([a-z]) is ([a-z])$/);
+    if (m) return `${m[2]} is ${m[1]}`;
+    m = label.match(/^([a-z]) is not ([a-z])$/);
+    if (m) return `${m[2]} is not ${m[1]}`;
+    return null;
+  };
+
+  it.each(SWEEP_SEEDS)(
+    'seed %i: no distractor is order-equivalent to the correct answer',
+    (seed) => {
+      for (const q of allQuestions(seed)) {
+        const correct = q.options.find((o) => q.correctId.includes(o.id))!;
+        const swapped = orderSwapped(correct.label);
+        for (const o of q.options) {
+          if (q.correctId.includes(o.id)) continue;
+          expect(
+            o.label,
+            `distractor equals correct answer for "${q.prompt}"`
+          ).not.toBe(correct.label);
+          if (swapped !== null) {
+            expect(
+              o.label,
+              `distractor "${o.label}" is order-equivalent to correct "${correct.label}" for "${q.prompt}"`
+            ).not.toBe(swapped);
+          }
+        }
+      }
+    }
+  );
+
+  it.each(SWEEP_SEEDS)(
+    "seed %i: *12 only/none-but switches the letters ('only C is A' = 'all A is C')",
+    (seed) => {
+      const qs = allQuestions(seed).filter((q) => q.id.startsWith('gen.A.12.'));
+      expect(qs.length).toBeGreaterThan(0);
+      for (const q of qs) {
+        expect(q.prompt).toMatch(/^(Only|None but) /);
+        const correct = q.options.find((o) => q.correctId.includes(o.id))!;
+        const m = correct.label.match(/^all ([A-Z]) is ([A-Z])$/);
+        expect(m, `"${correct.label}" is not an all-wff`).toBeTruthy();
+        // The classic didn't-switch mistake must be offered as a distractor.
+        expect(
+          q.options.some(
+            (o) =>
+              !q.correctId.includes(o.id) &&
+              o.label === `all ${m![2]} is ${m![1]}`
+          )
+        ).toBe(true);
+      }
+    }
+  );
 });
 
 describe('setA generator — streaming iterators', () => {

--- a/content/sets/setA.generator.ts
+++ b/content/sets/setA.generator.ts
@@ -186,7 +186,7 @@ function pickDifferentLetter<T extends string>(
 }
 
 // =============================================================
-// Easy templates: *0, *2, *3, *4, *5, *6, *7, *8, *9, *10, *11, *12
+// Easy templates: *0, *1, *2, *3, *4, *5, *6, *7, *8, *9, *10, *11
 // =============================================================
 
 /**
@@ -504,10 +504,13 @@ function template10(rng: Rng, counter: number): Question {
   const adjPred = pickDifferentLetter(rng, adjectives, noun);
   const adjSubj = pickDifferentLetter(rng, adjectives, adjPred);
   const A = noun[0]!.toUpperCase();
-  const a = noun[0]!.toLowerCase();
   const C = adjPred[0]!.toUpperCase();
   const c = adjPred[0]!.toLowerCase();
 
+  // Distractors follow 2008's *10 grid (`$h is $k`, `$h is $f`,
+  // `some $b`). A switched form (`some C is A`) must never appear
+  // here: Gensler treats `some A is B` and `some B is A` as the
+  // same wff, so it would be a correct answer marked wrong.
   return {
     id: qid('10', counter),
     prompt: `Some ${adjSubj} ${pluralize(noun)} are ${adjPred}.`,
@@ -515,8 +518,8 @@ function template10(rng: Rng, counter: number): Question {
       [
         { label: `some ${A} is ${C}` },
         { label: `${A} is ${C}` },
-        { label: `some ${a} is ${c}` },
-        { label: `some ${C} is ${A}`, layer2: HINT_SWITCHED },
+        { label: `${A} is ${c}`, layer2: classHint(adjPred) },
+        { label: `some ${A} is ${c}`, layer2: classHint(adjPred) },
       ],
       0
     ),
@@ -558,34 +561,34 @@ function template11(rng: Rng, counter: number): Question {
 }
 
 /**
- * *12 — "$S $C people are $As"  ($S = "Some" or "All")
+ * *12 — "$S $C people are $As"  ($S = "Only" (w=12) or "None but" (w=23))
  *
- *   "Some kind people are doctors." → some K is D
- *   "All cheerful people are scholars." → all C is S
+ *   "Only cheerful people are scholars." → all S is C
  *
- * Subject: "$C people" → CAPITAL (class of $C things).
- * Predicate: "$As" plural noun → CAPITAL (class).
+ * Gensler's only/none-but switching drill: ‘only’ and ‘none but’
+ * require switching the order of the letters — “$S A is B = all
+ * B is A” (2008 e-block, r=12/r=23). Options follow 2008's *12
+ * grid: `all $h is $k` (correct), `all $c` (didn't switch),
+ * `only $c` and `$k is $h` (non-wffs).
  */
 function template12(rng: Rng, counter: number): Question {
   const noun = pickFrom(rng, nounsProfessions);
   const adjSubj = pickDifferentLetter(rng, adjectives, noun);
   const C = adjSubj[0]!.toUpperCase();
-  const c = adjSubj[0]!.toLowerCase();
   const A = noun[0]!.toUpperCase();
-  const a = noun[0]!.toLowerCase();
-  const isAll = rng() < 0.5;
-  const Quant = isAll ? 'All' : 'Some';
-  const quant = isAll ? 'all' : 'some';
-  const otherQuant = isAll ? 'some' : 'all';
+  const sWord = rng() < 0.5 ? 'Only' : 'None but';
+  const switchHint = `You have to switch the parts around with ‘${sWord.toLowerCase()}.’ ‘${sWord} men are NFL football players’ doesn’t mean ‘all men are NFL football players’ — it means ‘all NFL football players are men.’`;
+  const onlyNotWffHint =
+    '‘Only’ isn’t part of the wff language — translate it as an ‘all’-sentence with the parts switched around.';
 
   return {
     id: qid('12', counter),
-    prompt: `${Quant} ${adjSubj} people are ${pluralize(noun)}.`,
+    prompt: `${sWord} ${adjSubj} people are ${pluralize(noun)}.`,
     ...buildOptions(
       [
-        { label: `${quant} ${C} is ${A}` },
-        { label: `${otherQuant} ${C} is ${A}` },
-        { label: `${quant} ${c} is ${a}` },
+        { label: `all ${A} is ${C}` },
+        { label: `all ${C} is ${A}`, layer2: switchHint },
+        { label: `only ${C} is ${A}`, layer2: onlyNotWffHint },
         { label: `${C} is ${A}` },
       ],
       0
@@ -594,8 +597,10 @@ function template12(rng: Rng, counter: number): Question {
   };
 }
 
+// 2008 split: easier = *0–*11, harder = *12–*23 (`C:wz%12 … Cm:ww+12`).
 const easyTemplates = [
   template0,
+  template1,
   template2,
   template3,
   template4,
@@ -606,11 +611,10 @@ const easyTemplates = [
   template9,
   template10,
   template11,
-  template12,
 ] as const;
 
 // =============================================================
-// Hard templates: *1, *13, *14, *15, *16, *17, *18, *19, *20, *21, *22
+// Hard templates: *12, *13, *14, *15, *16, *17, *18, *19, *20, *21, *22
 // =============================================================
 
 /**
@@ -928,7 +932,7 @@ function template22(rng: Rng, counter: number): Question {
 }
 
 const hardTemplates = [
-  template1,
+  template12,
   template13,
   template14,
   template15,

--- a/content/sets/setL.generator.test.ts
+++ b/content/sets/setL.generator.test.ts
@@ -150,6 +150,31 @@ describe('setL generator — property tests', () => {
       }
     }
   );
+
+  /** Textbook §12.1 / 2008 DSL *1 p=3: "Do A, only if you are doing
+   *  B" = (A̲ ⊃ B) — the underlined IMPERATIVE is the antecedent.
+   *  Keying the converse (Bu ⊃ A̲u) was a P0 (correct answer absent
+   *  from the options entirely). */
+  it('only-if prompts put the underlined imperative in the antecedent (all seeds)', () => {
+    const onlyIfQs = [1, 42, 99, 12345, 7, 314].flatMap((seed) =>
+      generateSetL(seed, 60)
+        .subSets.flatMap((s) => s.questions)
+        // Template-1 imperative only-if ("Do F, only if you E") —
+        // template 14's deontic "duty … only if possible" is a
+        // different, correctly non-underlined-antecedent form.
+        .filter((q) => /^Do \w+, only if you /.test(q.prompt))
+    );
+    expect(onlyIfQs.length).toBeGreaterThan(0);
+    for (const q of onlyIfQs) {
+      const correct = q.options.find((o) => q.correctId.includes(o.id))!;
+      // ($ (F\underline{u} \supset  Eu) $) — underline in the
+      // antecedent, plain descriptive u in the consequent.
+      expect(
+        /\([A-Z]\\underline\{u\} \\supset\s+[A-Z]u\)/.test(correct.label),
+        `"${correct.label}" (for "${q.prompt}") does not put the underlined imperative in the antecedent`
+      ).toBe(true);
+    }
+  });
 });
 
 describe('setL generator — streaming iterators', () => {

--- a/content/sets/setL.generator.ts
+++ b/content/sets/setL.generator.ts
@@ -295,14 +295,50 @@ function template0(rng: Rng, counter: number): Question {
  * *1 — Conditional imperatives.
  *   "If you're sleeping, then leave"   → (Su ⊃ L{u})
  *   "If you sleep, then don't leave"   → (Su ⊃ ∼L{u})
+ *   "Do leave, only if you're sleeping" → (L{u} ⊃ Su)
+ *
+ * 2008's *1 lists 4 paraphrases; the if-then ones share the
+ * "(Eu ⊃ ±Fu)" form, but the only-if paraphrase (p=3, DSL field
+ * `($eu_ ⊃ $fu)`) puts the underlined IMPERATIVE in the
+ * antecedent — textbook §12.1: "Do A, only if you (in fact) are
+ * doing B = (A̲ ⊃ B)", equivalent to "(∼B ⊃ ∼A̲)".
  */
 function template1(rng: Rng, counter: number): Question {
   const [eVerb, fVerb] = pickDistinctLetterPair(rng, verbsB);
   const E = eVerb[0]!.toUpperCase();
   const F = fVerb[0]!.toUpperCase();
   const negate = rng() < 0.5;
-  // Per Gensler §12.1: 2008 lists 4 paraphrases for *1; the
-  // first three share the "(Eu ⊃ ±Fu)" form.
+  const onlyIf = !negate && rng() < 1 / 3;
+  if (onlyIf) {
+    return buildQuestion(
+      1,
+      counter,
+      `Do ${fVerb}, only if you ${eVerb}.`,
+      [
+        { raw: `(${F}{u} ⊃ ${E}u)` },
+        {
+          raw: `(${E}u ⊃ ${F}{u})`,
+          layer2:
+            '‘Do A, only if B’ makes the imperative the antecedent: (A̲ ⊃ B) — the same as ‘If you aren’t ' +
+            gerund(eVerb) +
+            ', then don’t ' +
+            fVerb +
+            '’: (∼B ⊃ ∼A̲).',
+        },
+        {
+          raw: `(${F}u ⊃ ${E}u)`,
+          layer2:
+            HINT_FORGOT_UNDERLINE + ' (The antecedent is the imperative.)',
+        },
+        {
+          raw: `(${F}{u} · ${E}u)`,
+          layer2: '‘A only if B’ is a conditional `(A ⊃ B)`, not `(A · B)`.',
+        },
+      ],
+      0,
+      HINT_COND_IMP
+    );
+  }
   const prompt = negate
     ? pickFrom(rng, [
         `If you’re ${gerund(eVerb)}, then don’t ${fVerb}.`,
@@ -312,7 +348,6 @@ function template1(rng: Rng, counter: number): Question {
     : pickFrom(rng, [
         `If you’re ${gerund(eVerb)}, then ${fVerb}.`,
         `If you ${eVerb}, then ${fVerb}.`,
-        `Do ${fVerb}, only if you ${eVerb}.`,
       ]);
   const correct = negate ? `(${E}u ⊃ ∼${F}{u})` : `(${E}u ⊃ ${F}{u})`;
   return buildQuestion(

--- a/content/sets/setN.generator.test.ts
+++ b/content/sets/setN.generator.test.ts
@@ -177,6 +177,33 @@ describe('setN generator — property tests', () => {
       expect(unique.size).toBeGreaterThanOrEqual(5);
     }
   );
+
+  /** 2008 *15 / feedback *37 ("Underline both parts."): the willing
+   *  don't-combine forbids combining two ATTITUDES — both conjuncts
+   *  are willing formulas with the u before the colon underlined:
+   *  ∼(u̲:OAu̲ · ∼u̲:Au̲). A descriptive second conjunct (∼Au) was a
+   *  fidelity bug that graded the textbook-taught answer wrong. */
+  it.each([1, 42, 99, 12345])(
+    'seed %i: willing don’t-combine underlines both attitude conjuncts',
+    (seed) => {
+      // Willing is subSets[1]; the gen.N.4.* id prefix alone is
+      // ambiguous (believingNoPosition also numbers 4).
+      const qs = generateSetN(seed, 30).subSets[1]!.questions.filter((q) =>
+        q.id.startsWith('gen.N.4.')
+      );
+      expect(qs.length).toBeGreaterThan(0);
+      for (const q of qs) {
+        const correct = q.options.find((o) => q.correctId.includes(o.id))!;
+        // ∼(u̲:OAu̲ · ∼u̲:Au̲) with both u-before-colon underlined.
+        expect(
+          /\\sim \(\\underline\{u\}:O[A-Z]\\underline\{u\} \\cdot\s+\\sim \\underline\{u\}:[A-Z]\\underline\{u\}\)/.test(
+            correct.label
+          ),
+          `"${correct.label}" (for "${q.prompt}") does not underline both attitude conjuncts`
+        ).toBe(true);
+      }
+    }
+  );
 });
 
 describe('setN generator — streaming iterators', () => {

--- a/content/sets/setN.generator.ts
+++ b/content/sets/setN.generator.ts
@@ -90,7 +90,7 @@ const HINT_COND_BELIEF =
 const HINT_DONT_COMBINE_BELIEF =
   '‘Don’t combine believing A with believing B’ → `∼({u}:A · {u}:B)`. Forbids the conjunction; both inner u’s are imperative.';
 const HINT_DONT_COMBINE_WILL =
-  '‘Don’t combine wanting yourself to do A with not doing A’ → `∼({u}:A{u} · ∼Au)`. The first conjunct is your accepting the imperative to act; the second is your not actually doing it.';
+  '‘Don’t combine believing that you ought to do A with not acting to do A’ → `∼({u}:OA{u} · ∼{u}:A{u})`. Forbid the combination and underline both parts — believing and acting are both accepted with an imperative ‘u’.';
 const HINT_QUANT_BELIEVE =
   '‘Everyone believes that they ought to do A’ → `(x)x:OA{x}`. The outer (x) binds the believer, and the inner OA{x} says ‘you ought to do A’ for each x.';
 const HINT_WANT_SOMEONE =
@@ -184,10 +184,6 @@ function pickDifferentLetter<T extends string>(
     (x) => x[0]!.toLowerCase() !== avoid[0]!.toLowerCase()
   );
   return pickFrom(rng, filtered.length > 0 ? filtered : pool);
-}
-
-function gerund(verb: string): string {
-  return verb + 'ing';
 }
 
 function qid(num: number, n: number): string {
@@ -727,42 +723,50 @@ function willingResolve(rng: Rng, counter: number): Question {
   );
 }
 
-/** Don't combine willing: "Don't combine wanting A with not doing A" → ∼({u}:A{u} · ∼A{u}) */
+/**
+ * Don't combine willing — Gensler's conscientiousness drill (2008 *15):
+ * "Don't combine believing that you ought to A with not acting to A"
+ *   → ∼({u}:OA{u} · ∼{u}:A{u})
+ *
+ * Both conjuncts are willing formulas with the u before the colon
+ * underlined (2008 feedback: "Underline both parts."); "acting to
+ * do A" is `u̲:Au̲`, never bare descriptive `Au`. Options mirror
+ * 2008's grid: a `∼(u̲:OAu̲ · ∼u̲:Au̲)`, b `∼(u̲:OAu̲ · ∼Au̲)`,
+ * c `(u:OAu̲ · ∼u̲:Au̲)`, d `(u:OAu̲ · ∼Au̲)`.
+ */
 function willingDontCombine(rng: Rng, counter: number): Question {
   const verb = pickFrom(rng, verbsB);
   const V = verb[0]!.toUpperCase();
   const prompt = pickFrom(rng, [
-    `Don’t combine wanting yourself to ${verb} with not ${gerund(verb)}.`,
-    `Don’t want to ${verb} without actually ${gerund(verb)}.`,
-    `Don’t both want yourself to ${verb} and fail to ${verb}.`,
+    `Don’t combine believing that you ought to ${verb} with not acting to ${verb}.`,
+    `Don’t believe that you ought to ${verb} without acting to ${verb}.`,
   ]);
   return buildQuestion(
     4,
     counter,
     prompt,
     [
-      { raw: `∼({u}:${V}{u} · ∼${V}u)` },
+      { raw: `∼({u}:O${V}{u} · ∼{u}:${V}{u})` },
       {
-        raw: `({u}:${V}{u} ⊃ ${V}u)`,
+        raw: `∼({u}:O${V}{u} · ∼${V}{u})`,
         layer2:
-          '‘Don’t combine A with B’ is the don’t-combine form `∼(A · B)`, not the if-then `(A ⊃ ∼B)`.',
-      },
-      {
-        raw: `∼({u}:${V}{u} · ∼${V}{u})`,
-        layer2:
-          'The second conjunct is descriptive (you don’t actually ' +
+          '‘Acting to ' +
           verb +
-          ') — don’t underline the u in ' +
+          '’ is itself a willing formula — `{u}:' +
           V +
-          'u.',
+          '{u}`, not bare `' +
+          V +
+          '{u}`. Underline both parts, including the u before the second colon.',
       },
       {
-        raw: `∼({u}:${V}u · ∼${V}u)`,
+        raw: `(u:O${V}{u} · ∼{u}:${V}{u})`,
         layer2:
-          HINT_FORGOT_UNDERLINE_U +
-          ' (The inner ' +
-          V +
-          '{u} is imperative — what you’re wanting yourself to do.)',
+          'Use a formula that forbids a combination — the don’t-combine imperative is `∼( · )` with the u’s before the colons underlined.',
+      },
+      {
+        raw: `(u:O${V}{u} · ∼${V}{u})`,
+        layer2:
+          'This describes you (a statement), it doesn’t forbid anything — the imperative is `∼( · )` with both parts underlined.',
       },
     ],
     0,


### PR DESCRIPTION
Fixes the three fidelity bugs found in the 2026-07-25 answer-key audit of all live sets against the decoded 2008 LogiCola engine DSL and Gensler, *Introduction to Logic* (3rd ed.). All three were in port-authored deviations; everything transcribed from 2008 audited clean.

## Set A, template *10 — correct answer marked wrong (P0)

The port-invented distractor `some C is A` is the **same wff** as the correct `some A is C`: Gensler's 2008 grader explicitly accepts reversed letters for the four order-insensitive forms ("some A is B = some B is A"). A student giving a correct translation was marked wrong and hinted at with false doctrine. Restored 2008's actual distractor grid (`A is C`, `A is c`, `some A is c`).

## Set A, template *12 — Only/None-but drill was missing (P1)

2008's *12 is the only/none-but letter-switching drill ("Only cheerful people are scholars" → `all S is C`, per the e-block rule "$S A is B = all B is A"); the port had replaced it with a plain All/Some drill, so the idiom was drilled nowhere and the "None but" variant was dropped. Restored, with 2008's distractor grid and the NFL-example hint. Also re-seated *1/*12 to 2008's easy/hard split (easy = *0–*11, hard = *12–*23).

## Set L, template *1 — only-if keyed to the converse (P0)

"Do F, only if you E" was keyed to `(Eu ⊃ F̲u)`; per textbook §12.1 and DSL *1 p=3, the underlined imperative is the **antecedent**: `(F̲u ⊃ Eu)` ("means the same as (∼B ⊃ ∼A̲)"). The true answer wasn't among the options, so ~1.7% of Set L draws were unanswerable. The only-if paraphrase now has its own correctly keyed branch.

## Set N, willing don't-combine — drilled against the textbook (P1)

The authored prompt ("wanting yourself to V with not actually V-ing") replaced Gensler's conscientiousness drill and its hints taught the opposite of 2008's feedback ("Underline both parts."). Restored 2008 *15: "Don't combine believing that you ought to V with not acting to V" → `∼(u̲:OVu̲ · ∼u̲:Vu̲)`, with 2008's four-option grid. The Layer-1 hint now states the faithful rule.

## Regression guards

Each fix ships a property test encoding the domain rule itself (not just snapshots): no distractor may be order-equivalent to the correct answer; only-if imperatives must have the underlined antecedent; both willing conjuncts must be underlined.

`vitest`: 215/215 pass. `tsc`, `eslint`, `prettier`: clean.

Branch is cut from `origin/main` and contains only this fix — none of the in-flight local work.
