### PR TITLE
feat(analytics): capture question_answered with template and option detail

### DIFF
--- a/components/quiz/useQuizState.test.ts
+++ b/components/quiz/useQuizState.test.ts
@@ -123,6 +123,10 @@ describe('Navigation between questions', () => {
 });
 
 describe('Option selection and scoring', () => {
+  beforeEach(() => {
+    vi.mocked(captureAnalyticsEvent).mockClear();
+  });
+
   it('selects an option and increments score if the answer is correct', async () => {
     const { result } = renderHook(() => useQuizState(mockQuiz));
 
@@ -206,7 +210,12 @@ describe('Option selection and scoring', () => {
       result.current.onShowStartScreen();
     });
 
-    expect(captureAnalyticsEvent).toHaveBeenCalledTimes(1);
+    // Filter by event name — question_answered events from other
+    // interactions must not count against the once-only guarantee.
+    const quizStartedCalls = vi
+      .mocked(captureAnalyticsEvent)
+      .mock.calls.filter(([eventName]) => eventName === 'quiz_started');
+    expect(quizStartedCalls).toHaveLength(1);
     expect(captureAnalyticsEvent).toHaveBeenCalledWith(
       'quiz_started',
       expect.objectContaining({
@@ -219,6 +228,38 @@ describe('Option selection and scoring', () => {
         total_questions: mockQuiz.questions.length,
       })
     );
+  });
+
+  it('captures question_answered with template key and option detail on every check', async () => {
+    const { result } = renderHook(() => useQuizState(mockQuiz));
+
+    await waitFor(() => {
+      expect(result.current.currentQuestion).toBeDefined();
+    });
+
+    const q = result.current.currentQuestion!;
+    const wrongIndex = q.options.findIndex((o) => !q.correctId.includes(o.id));
+
+    act(() => {
+      result.current.selectOption(wrongIndex);
+    });
+    act(() => {
+      result.current.onCheckAnswer();
+    });
+
+    const calls = vi
+      .mocked(captureAnalyticsEvent)
+      .mock.calls.filter(([eventName]) => eventName === 'question_answered');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]![1]).toMatchObject({
+      question_id: q.id,
+      option_id: q.options[wrongIndex]!.id,
+      option_label: q.options[wrongIndex]!.label,
+      correct: false,
+      guess_number: 1,
+      first_try: true,
+      quiz_id: mockQuiz.id,
+    });
   });
 
   it('completes after 10 questions and scores against a 10-question quiz', async () => {

--- a/components/quiz/useQuizState.tsx
+++ b/components/quiz/useQuizState.tsx
@@ -169,6 +169,18 @@ export default function useQuizState(subSet: SubSet) {
   }
 
   /**
+   * Stable per-template analytics key. Generated ids ("gen.A.10.3")
+   * drop the draw counter → "gen.A.10", so one template's answers
+   * aggregate under one value; static ids (e.g. Set Q's "3.1") are
+   * already stable and pass through unchanged.
+   */
+  function questionTemplateKey(questionId: string): string {
+    return questionId.startsWith('gen.')
+      ? questionId.split('.').slice(0, 3).join('.')
+      : questionId;
+  }
+
+  /**
    * The user pressed "Check Answer"
    */
   function onCheckAnswer() {
@@ -176,9 +188,28 @@ export default function useQuizState(subSet: SubSet) {
 
     // Retrieve the chosen option object
     const chosenOption = currentQuestion.options[selectedOptionIndex];
+    const correct = isAnswerCorrect(chosenOption.id, currentQuestion.correctId);
+
+    // One event per Check Answer press (so a question answered
+    // wrong twice emits two events). `question_template` is the
+    // per-template aggregation key; `option_label` records which
+    // distractor pulled the miss — the pair that makes content
+    // bugs (a distractor drawing correct-answer-level traffic)
+    // visible in PostHog.
+    void captureAnalyticsEvent('question_answered', {
+      ...buildQuizAnalyticsProperties(subSet, totalQuestionCount),
+      question_id: currentQuestion.id,
+      question_template: questionTemplateKey(currentQuestion.id),
+      question_prompt: currentQuestion.prompt,
+      option_id: chosenOption.id,
+      option_label: chosenOption.label,
+      correct,
+      guess_number: previousGuesses.length + 1,
+      first_try: previousGuesses.length === 0,
+    });
 
     // Use the helper function to see if the chosen option is correct
-    if (isAnswerCorrect(chosenOption.id, currentQuestion.correctId)) {
+    if (correct) {
       if (previousGuesses.length === 0) {
         setCorrectQuestions((prev) => [...prev, currentQuestion.id]);
       }


### PR DESCRIPTION
Adds a `question_answered` PostHog event — one per Check Answer press — so per-question behaviour is analysable at all. Until now only `quiz_started` / `quiz_completed` / `quiz_retried` existed, which is why the three fidelity bugs fixed in #161 were invisible in analytics: nothing recorded which options students picked or which templates drew abnormal miss rates.

Properties per event:

- all existing quiz-level properties (`quiz_id`, `quiz_slug`, …)
- `question_id` — full id (e.g. `gen.A.10.3`)
- `question_template` — stable aggregation key (`gen.A.10`; static ids pass through)
- `question_prompt`, `option_id`, `option_label` — which distractor pulled the miss
- `correct`, `guess_number`, `first_try`

The pair `question_template` × `option_label` is the one that makes content bugs visible: a distractor drawing correct-answer-level pick rates (like `some C is A` in `gen.A.10`) shows up as an outlier without anyone re-auditing the source.

Tests: covers the new event, scopes the existing once-only `quiz_started` assertion by event name, and adds the missing mock reset to the `Option selection and scoring` describe block (call counts were leaking across tests). 203/203 pass.

Note for the in-flight scored-run work: this touches `onCheckAnswer` in `useQuizState.tsx`, so expect a small, mechanical conflict when that lands — the capture block just needs to stay at the top of `onCheckAnswer`.
